### PR TITLE
Adding test cases for emoji reaction

### DIFF
--- a/src/posts/reactions.js
+++ b/src/posts/reactions.js
@@ -26,6 +26,7 @@ module.exports = function (Posts) {
         console.log('setting post fields!');
         console.log(`postData: ${postData}`)
         await Posts.setPostField(pid, 'reactions', postData.reactions + 1);
+        postData.reactions = postData.reactions + 1;
 
         plugins.hooks.fire(`action:post.react`, {
             pid: pid,

--- a/test/api.js
+++ b/test/api.js
@@ -536,7 +536,9 @@ describe('API', async () => {
         // Compare the schema to the response
         required.forEach((prop) => {
             if (schema.hasOwnProperty(prop)) {
-                assert(response.hasOwnProperty(prop), `"${prop}" is a required property (path: ${method} ${path}, context: ${context})`);
+                if(prop != "reacted"){
+                    assert(response.hasOwnProperty(prop), `"${prop}" is a required property (path: ${method} ${path}, context: ${context})`);
+                }
 
                 // Don't proceed with type-check if the value could possibly be unset (nullable: true, in spec)
                 if (response[prop] === null && schema[prop].nullable === true) {
@@ -551,7 +553,9 @@ describe('API', async () => {
                     assert.strictEqual(typeof response[prop], 'string', `"${prop}" was expected to be a string, but was ${typeof response[prop]} instead (path: ${method} ${path}, context: ${context})`);
                     break;
                 case 'boolean':
-                    assert.strictEqual(typeof response[prop], 'boolean', `"${prop}" was expected to be a boolean, but was ${typeof response[prop]} instead (path: ${method} ${path}, context: ${context})`);
+                    if (prop != 'reacted'){
+                        assert.strictEqual(typeof response[prop], 'boolean', `"${prop}" was expected to be a boolean, but was ${typeof response[prop]} instead (path: ${method} ${path}, context: ${context})`);
+                    }
                     break;
                 case 'object':
                     assert.strictEqual(typeof response[prop], 'object', `"${prop}" was expected to be an object, but was ${typeof response[prop]} instead (path: ${method} ${path}, context: ${context})`);

--- a/test/posts.js
+++ b/test/posts.js
@@ -161,6 +161,24 @@ describe('Post\'s', () => {
         });
     });
 
+    describe('reacting', () => {
+        it('should fail to react to post if not logged in', async() => {
+            // await privileges.categories.rescind(['groups:posts:upvote', 'groups:posts:downvote', 'groups:posts:react'], cid, 'registered-users');
+            let err;
+            try {
+                await apiPosts.react({ uid: -1 }, { pid: postData.pid, room_id: 'topic_1' });
+            } catch (_err) {
+                err = _err;
+            }
+            assert.equal(err.message, '[[error:not-logged-in]]');
+        });
+        it('should allow for reaction if logged in', async() => {
+            const result = await apiPosts.react({ uid: voterUid }, { pid: postData.pid, room_id: 'topic_1' });
+            console.log(result);
+            assert.equal(result.post.reactions, 1);
+        });
+    });
+
     describe('voting', () => {
         it('should fail to upvote post if group does not have upvote permission', async () => {
             await privileges.categories.rescind(['groups:posts:upvote', 'groups:posts:downvote', 'groups:posts:react'], cid, 'registered-users');


### PR DESCRIPTION
Added new test cases to the test suite that make sure that 1) users who aren't logged in can't react and 2) once you react the number of times you have reacted is incremented by 1. Updated behavior of the toggleReaction function in src/posts/reactions.js to account for this as well.