### PR TITLE
Implemented Retire Static Analysis Tool

### DIFF
--- a/retire-output.txt
+++ b/retire-output.txt
@@ -1,0 +1,2 @@
+retire.js v5.0.0-beta.1
+Loading from cache: https://raw.githubusercontent.com/RetireJS/retire.js/master/repository/jsrepository-v2.json


### PR DESCRIPTION
Locally installed retire static analysis tool. Ran the code with -v flag in order to get a list of files that have vulnerable libraries being used. The vulnerability is determined from either outdatedness or the overall severity of the library itself.  Along with the list of files, it also lists the library and the version that is being used.

The output is listed in [retire-output.txt](https://github.com/CMU-313/spring24-nodebb-ccc/files/14610650/retire-output.txt).
